### PR TITLE
Add `counter(_: to:)` function.

### DIFF
--- a/SwiftCommons/Functions.swift
+++ b/SwiftCommons/Functions.swift
@@ -20,17 +20,33 @@ public func ngt(_ x: Int) -> Int {
     return -x
 }
 
+
+public func ..< <T>(leftBound: T, rightBound: T) -> StrideTo<T> {
+    return stride(from: leftBound, to: rightBound, by: 1)
+}
+
+public func ... <T>(leftBound: T, rightBound: T) -> StrideThrough<T> {
+    return stride(from: leftBound, through: rightBound, by: 1)
+}
+
 /**
  Returns the sequence for sequentially getting values using an Array's subscript.
  
  This function is safe because it creates the sequence with `stride(_: to: by:)` function.
- ```
- let empty: [Int] = []
- let counter = counter(0, empty.endIndex-1) // not crash
- ```
+ 
  */
-public func counter(_ from: Int = 0, to: Int) -> StrideTo<Int> {
-    return stride(from: from, to: to, by: 1)
+public func counter<T>(_ range: StrideTo<T>) -> StrideTo<T> {
+    return range
+}
+
+/**
+ Returns the sequence for sequentially getting values using an Array's subscript.
+ 
+ This function is safe because it creates the sequence with `stride(_: through: by:)` function.
+ 
+ */
+public func counter<T>(_ range: StrideThrough<T>) -> StrideThrough<T> {
+    return range
 }
 
 public func screenSize() -> CGSize {

--- a/SwiftCommons/Functions.swift
+++ b/SwiftCommons/Functions.swift
@@ -20,6 +20,19 @@ public func ngt(_ x: Int) -> Int {
     return -x
 }
 
+/**
+ Returns the sequence for sequentially getting values using an Array's subscript.
+ 
+ This function is safe because it creates the sequence with `stride(_: to: by:)` function.
+ ```
+ let empty: [Int] = []
+ let counter = counter(0, empty.endIndex-1) // not crash
+ ```
+ */
+public func counter(_ from: Int = 0, to: Int) -> StrideTo<Int> {
+    return stride(from: from, to: to, by: 1)
+}
+
 public func screenSize() -> CGSize {
     return UIScreen.main.bounds.size
 }

--- a/SwiftCommonsTests/FunctionsTests.swift
+++ b/SwiftCommonsTests/FunctionsTests.swift
@@ -43,4 +43,13 @@ class FunctionsTests: XCTestCase {
         XCTAssertEqual(-2, ngt(2))
         XCTAssertEqual(2, ngt(-2))
     }
+    
+    func test_counter() {
+        XCTAssertEqual(Array(counter(to: 1)), [0])
+        XCTAssertEqual(Array(counter(1, to: 3)), [1,2])
+        XCTAssertEqual(Array(counter(2, to: 5)), [2,3,4])
+        
+        XCTAssertEqual(Array(counter(0, to: -1)), [])
+        XCTAssertEqual(Array(counter(1, to: 1)), [])
+    }
 }

--- a/SwiftCommonsTests/FunctionsTests.swift
+++ b/SwiftCommonsTests/FunctionsTests.swift
@@ -45,11 +45,18 @@ class FunctionsTests: XCTestCase {
     }
     
     func test_counter() {
-        XCTAssertEqual(Array(counter(to: 1)), [0])
-        XCTAssertEqual(Array(counter(1, to: 3)), [1,2])
-        XCTAssertEqual(Array(counter(2, to: 5)), [2,3,4])
+        XCTAssertEqual(Array(counter(0..<1)), [0])
+        XCTAssertEqual(Array(counter(1..<3)), [1,2])
+        XCTAssertEqual(Array(counter(2..<5)), [2,3,4])
         
-        XCTAssertEqual(Array(counter(0, to: -1)), [])
-        XCTAssertEqual(Array(counter(1, to: 1)), [])
+        XCTAssertEqual(Array(counter(0..<(-1))), [])
+        XCTAssertEqual(Array(counter(1..<1)), [])
+        
+        XCTAssertEqual(Array(counter(0...0)), [0])
+        XCTAssertEqual(Array(counter(0...1)), [0,1])
+        XCTAssertEqual(Array(counter(1...3)), [1,2,3])
+        XCTAssertEqual(Array(counter(2...5)), [2,3,4,5])
+        
+        XCTAssertEqual(Array(counter(0...(-1))), [])
     }
 }


### PR DESCRIPTION
この関数を使えば安全に配列の添字子を使って順次アクセスが出来ます。
This function can safely access sequential with Array's subscript function.

Example1:   

```
let array = [1,2,3,4,5]
for i in counter(to: array.endIndex) {
    print(array[i])
}
```

Example2:  

```
let empty: Int = []
for i in counter(to: array.endIndex - 1) { // This doesn't crash but 0..<-1 cause a crash.
}
```

